### PR TITLE
Add Polygon/Mumbai support to list of providers

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -40,7 +40,9 @@ const multicallAddresses = {
   42: '0x2cc8688c5f75e365aaeeb4ea8d6a480405a48d2a',
   56: '0x1Ee38d535d541c55C9dae27B12edf090C608E6Fb',
   100: '0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a',
+  137: '0xc4f1501f337079077842343Ce02665D8960150B0',
   1337: '0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e',
+  80001: '0x5a0439824F4c0275faa88F2a7C5037F9833E29f1'
 };
 
 export function setMulticallAddress(chainId: number, address: string) {


### PR DESCRIPTION
Both tested directly with 
```javascript
  setMulticallAddress(137, '0xc4f1501f337079077842343Ce02665D8960150B0')
  setMulticallAddress(80001, '0x5a0439824F4c0275faa88F2a7C5037F9833E29f1')
```
before use it as provider