### PR TITLE
Do not import ethers

### DIFF
--- a/src/abi.ts
+++ b/src/abi.ts
@@ -1,25 +1,28 @@
-import { ethers } from 'ethers';
+import { AbiCoder, ParamType } from '@ethersproject/abi';
+import type { BytesLike } from '@ethersproject/bytes';
+import { keccak256 } from '@ethersproject/keccak256';
+import { toUtf8Bytes } from '@ethersproject/strings';
 
 export class Abi {
-  public static encode(name: string, inputs: ethers.utils.ParamType[], params: any[]) {
+  public static encode(name: string, inputs: ParamType[], params: any[]) {
     const functionSignature = getFunctionSignature(name, inputs);
-    const functionHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(functionSignature));
+    const functionHash = keccak256(toUtf8Bytes(functionSignature));
     const functionData = functionHash.substring(2, 10);
-    const abiCoder = new ethers.utils.AbiCoder();
+    const abiCoder = new AbiCoder();
     const argumentString = abiCoder.encode(inputs, params);
     const argumentData = argumentString.substring(2);
     const inputData = `0x${functionData}${argumentData}`;
     return inputData;
   }
 
-  public static decode(outputs: ethers.utils.ParamType[], data: ethers.utils.BytesLike) {
-    const abiCoder = new ethers.utils.AbiCoder();
+  public static decode(outputs: ParamType[], data: BytesLike) {
+    const abiCoder = new AbiCoder();
     const params = abiCoder.decode(outputs, data);
     return params;
   }
 }
 
-function getFunctionSignature(name: string, inputs: ethers.utils.ParamType[]) {
+function getFunctionSignature(name: string, inputs: ParamType[]) {
   const types = [];
   for (const input of inputs) {
     if (input.type === 'tuple') {

--- a/src/call.ts
+++ b/src/call.ts
@@ -1,4 +1,6 @@
-import { ethers } from 'ethers';
+import { Contract } from '@ethersproject/contracts';
+import type { Provider } from '@ethersproject/providers';
+
 import { Abi } from './abi';
 import { multicallAbi } from './abi/multicall';
 import { ContractCall } from './types';
@@ -6,10 +8,10 @@ import { ContractCall } from './types';
 export async function all<T extends any[] = any[]>(
   calls: ContractCall[],
   multicallAddress: string,
-  provider: ethers.providers.Provider,
+  provider: Provider,
 ): Promise<T> {
-  const multicall = new ethers.Contract(multicallAddress, multicallAbi, provider);
-  const callRequests = calls.map(call => {
+  const multicall = new Contract(multicallAddress, multicallAbi, provider);
+  const callRequests = calls.map((call) => {
     const callData = Abi.encode(call.name, call.inputs, call.params);
     return {
       target: call.contract.address,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,5 +1,4 @@
 import { Fragment, FunctionFragment, JsonFragment } from '@ethersproject/abi';
-import { utils } from 'ethers';
 
 export class Contract {
   private _address: string;
@@ -23,8 +22,12 @@ export class Contract {
 
     this._abi = toFragment(abi);
 
-    this._functions = this._abi.filter(x => x.type === 'function').map(x => FunctionFragment.from(x));
-    const callFunctions = this._functions.filter(x => x.stateMutability === 'pure' || x.stateMutability === 'view');
+    this._functions = this._abi
+      .filter((x) => x.type === 'function')
+      .map((x) => FunctionFragment.from(x));
+    const callFunctions = this._functions.filter(
+      (x) => x.stateMutability === 'pure' || x.stateMutability === 'view',
+    );
 
     for (const callFunction of callFunctions) {
       const { name } = callFunction;
@@ -39,14 +42,14 @@ export class Contract {
 }
 
 function toFragment(abi: JsonFragment[] | string[] | Fragment[]): Fragment[] {
-  return abi.map((item: JsonFragment | string | Fragment) => utils.Fragment.from(item));
+  return abi.map((item: JsonFragment | string | Fragment) => Fragment.from(item));
 }
 
 function makeCallFunction(contract: Contract, name: string) {
   return (...params: any[]) => {
     const { address } = contract;
-    const { inputs } = contract.functions.find(f => f.name === name);
-    const { outputs } = contract.functions.find(f => f.name === name);
+    const { inputs } = contract.functions.find((f) => f.name === name);
+    const { outputs } = contract.functions.find((f) => f.name === name);
     return {
       contract: {
         address,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,13 +1,14 @@
-import { ethers } from 'ethers';
+import { Provider as EthersProvider } from '@ethersproject/providers';
+
 import { all } from './call';
 import { getEthBalance } from './calls';
 import { ContractCall } from './types';
 
 export class Provider {
-  private _provider: ethers.providers.Provider;
+  private _provider: EthersProvider;
   private _multicallAddress: string;
 
-  constructor(provider: ethers.providers.Provider, chainId?: number) {
+  constructor(provider: EthersProvider, chainId?: number) {
     this._provider = provider;
     this._multicallAddress = getAddressForChainId(chainId);
   }
@@ -42,7 +43,7 @@ const multicallAddresses = {
   100: '0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a',
   137: '0xc4f1501f337079077842343Ce02665D8960150B0',
   1337: '0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e',
-  80001: '0x5a0439824F4c0275faa88F2a7C5037F9833E29f1'
+  80001: '0x5a0439824F4c0275faa88F2a7C5037F9833E29f1',
 };
 
 export function setMulticallAddress(chainId: number, address: string) {
@@ -53,7 +54,7 @@ function getAddressForChainId(chainId: number) {
   return multicallAddresses[chainId];
 }
 
-async function getAddress(provider: ethers.providers.Provider) {
+async function getAddress(provider: EthersProvider) {
   const { chainId } = await provider.getNetwork();
   return getAddressForChainId(chainId);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
-import { ethers } from 'ethers';
+import type { ParamType } from '@ethersproject/abi';
 
 export interface ContractCall {
   contract: {
     address: string;
   };
   name: string;
-  inputs: ethers.utils.ParamType[];
-  outputs: ethers.utils.ParamType[];
+  inputs: ParamType[];
+  outputs: ParamType[];
   params: any[];
 }


### PR DESCRIPTION
Hi. I've been working on a dapp and noticed that importing `ethers` directly causes a lot of bloat to be added in my JS bundles. I've changed all the imports so we import directly from `@ethersproject/*` packages instead. I've did this for my app and noticed my bundle sizes drop.