### PR TITLE
Removed 'ethers' imports and replaced them with more specific imports

### DIFF
--- a/src/abi.ts
+++ b/src/abi.ts
@@ -1,25 +1,28 @@
-import { ethers } from 'ethers';
+import {AbiCoder, ParamType} from '@ethersproject/abi';
+import {BytesLike} from '@ethersproject/bytes';
+import {keccak256} from '@ethersproject/keccak256';
+import {toUtf8Bytes} from '@ethersproject/strings';
 
 export class Abi {
-  public static encode(name: string, inputs: ethers.utils.ParamType[], params: any[]) {
+  public static encode(name: string, inputs: ParamType[], params: any[]) {
     const functionSignature = getFunctionSignature(name, inputs);
-    const functionHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(functionSignature));
+    const functionHash = keccak256(toUtf8Bytes(functionSignature));
     const functionData = functionHash.substring(2, 10);
-    const abiCoder = new ethers.utils.AbiCoder();
+    const abiCoder = new AbiCoder();
     const argumentString = abiCoder.encode(inputs, params);
     const argumentData = argumentString.substring(2);
     const inputData = `0x${functionData}${argumentData}`;
     return inputData;
   }
 
-  public static decode(outputs: ethers.utils.ParamType[], data: ethers.utils.BytesLike) {
-    const abiCoder = new ethers.utils.AbiCoder();
+  public static decode(outputs: ParamType[], data: BytesLike) {
+    const abiCoder = new AbiCoder();
     const params = abiCoder.decode(outputs, data);
     return params;
   }
 }
 
-function getFunctionSignature(name: string, inputs: ethers.utils.ParamType[]) {
+function getFunctionSignature(name: string, inputs: ParamType[]) {
   const types = [];
   for (const input of inputs) {
     if (input.type === 'tuple') {

--- a/src/call.ts
+++ b/src/call.ts
@@ -1,4 +1,6 @@
-import { ethers } from 'ethers';
+import {Contract} from '@ethersproject/contracts';
+import {Provider} from '@ethersproject/providers';
+
 import { Abi } from './abi';
 import { multicallAbi } from './abi/multicall';
 import { ContractCall } from './types';
@@ -6,9 +8,9 @@ import { ContractCall } from './types';
 export async function all<T extends any[] = any[]>(
   calls: ContractCall[],
   multicallAddress: string,
-  provider: ethers.providers.Provider,
+  provider: Provider,
 ): Promise<T> {
-  const multicall = new ethers.Contract(multicallAddress, multicallAbi, provider);
+  const multicall = new Contract(multicallAddress, multicallAbi, provider);
   const callRequests = calls.map(call => {
     const callData = Abi.encode(call.name, call.inputs, call.params);
     return {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,5 +1,4 @@
 import { Fragment, FunctionFragment, JsonFragment } from '@ethersproject/abi';
-import { utils } from 'ethers';
 
 export class Contract {
   private _address: string;
@@ -39,7 +38,7 @@ export class Contract {
 }
 
 function toFragment(abi: JsonFragment[] | string[] | Fragment[]): Fragment[] {
-  return abi.map((item: JsonFragment | string | Fragment) => utils.Fragment.from(item));
+  return abi.map((item: JsonFragment | string | Fragment) => Fragment.from(item));
 }
 
 function makeCallFunction(contract: Contract, name: string) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,13 +1,13 @@
-import { ethers } from 'ethers';
+import {Provider as EthersProvider} from '@ethersproject/abstract-provider';
 import { all } from './call';
 import { getEthBalance } from './calls';
 import { ContractCall } from './types';
 
 export class Provider {
-  private _provider: ethers.providers.Provider;
+  private _provider: EthersProvider;
   private _multicallAddress: string;
 
-  constructor(provider: ethers.providers.Provider, chainId?: number) {
+  constructor(provider: EthersProvider, chainId?: number) {
     this._provider = provider;
     this._multicallAddress = getAddressForChainId(chainId);
   }
@@ -59,7 +59,7 @@ function getAddressForChainId(chainId: number) {
   return multicallAddresses[chainId];
 }
 
-async function getAddress(provider: ethers.providers.Provider) {
+async function getAddress(provider: EthersProvider) {
   const { chainId } = await provider.getNetwork();
   return getAddressForChainId(chainId);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
-import { ethers } from 'ethers';
+import {ParamType} from '@ethersproject/abi';
 
 export interface ContractCall {
   contract: {
     address: string;
   };
   name: string;
-  inputs: ethers.utils.ParamType[];
-  outputs: ethers.utils.ParamType[];
+  inputs: ParamType[];
+  outputs: ParamType[];
   params: any[];
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,8 @@
+import {InfuraProvider} from '@ethersproject/providers';
 import { assert } from 'chai';
-import { ethers } from 'ethers';
 import { Contract, Provider } from '../src';
 
-const provider = new ethers.providers.InfuraProvider('mainnet');
+const provider = new InfuraProvider('mainnet');
 const ethcallProvider = new Provider(provider, 1);
 
 it('human readable abi', async () => {


### PR DESCRIPTION
Pretty much the same changes as https://github.com/cavanmflynn/ethers-multicall/pull/15 except for the current state of the repo. 

To show the impact, this is my package build with the current version of ethers-multicall
```asset index.js 619 KiB [emitted] [minimized] [big] (name: main) 1 related asset```
And here it is with the improved imports
```asset index.js 415 KiB [emitted] [minimized] [big] (name: main) 1 related asset```