### PR TITLE
Fix dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "@ethersproject/abi": "^5.0.0",
+    "@ethersproject/contracts": "^5.0.0",
+    "@ethersproject/keccak256": "^5.0.0",
+    "@ethersproject/strings": "^5.0.0",
     "ethers": "^5.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
I have a problem with the installation of your package to my project that uses _[zero-Installs](https://yarnpkg.com/features/zero-installs)_ methodology.
Due to a lack of dependencies in the package.json file. I had to add the next dependencies to _.yarnrc.yml_ file

```
packageExtensions:
    ethers-multicall@*:
      dependencies:
        "@ethersproject/abi": "*"
        "@ethersproject/contracts": "*"
        "@ethersproject/keccak256": "*"
        "@ethersproject/strings": "*"
```

I'm not sure but the next changes may help to resolve the problem. Please check 


Fix Error: 

_ethers-multicall tried to access @ethersproject/contracts, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound_

This version package has been taken from yarn.lock file